### PR TITLE
Update Dockerfile

### DIFF
--- a/mvn-jdk-node/Dockerfile
+++ b/mvn-jdk-node/Dockerfile
@@ -6,6 +6,7 @@ FROM maven:${mvn_version}-openjdk-${jdk_version}
 RUN groupadd --gid 1000 node \
   && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
 
+ARG node_version=15.4.0
 ENV NODE_VERSION=${node_version:-15.4.0}
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
The docker build command passes the correct version, 14.16.0:
docker build -t steampunkfoundry/mvn-jdk-node:sab-53680-edae-docker-2 --network container:0ac53985aa79 --build-arg 'mvn_version=3.6.3' --build-arg 'jdk_version=11' --build-arg 'node_version=**_14.16.0_**' mvn-jdk-node

But it ends up installing 15.4.0:
curl -fsSLO --compressed https://nodejs.org/dist/v15.4.0/node-v**_15.4.0_**-linux-x64.tar.xz
node --version
v**_15.4.0_**
